### PR TITLE
Do not set fps attribute directly, use set_fps()

### DIFF
--- a/fairmotion/core/motion.py
+++ b/fairmotion/core/motion.py
@@ -350,6 +350,10 @@ class Motion(object):
         self.poses = []
         self.info = {}
 
+    def set_fps(self, fps):
+        self.fps = fps
+        self.fps_inv = 1.0 / fps
+
     def set_skeleton(self, skel):
         self.skel = skel
         for idx in range(len(self.poses)):

--- a/fairmotion/data/amass_dip.py
+++ b/fairmotion/data/amass_dip.py
@@ -136,7 +136,7 @@ def load(
     if load_motion:
         assert motion.skel is not None
         # Assume 60fps
-        motion.fps = 60.0
+        motion.set_fps(60.0)
         dt = float(1 / motion.fps)
         with open(file, "rb") as f:
             data = pkl.load(f, encoding="latin1")

--- a/fairmotion/data/bvh.py
+++ b/fairmotion/data/bvh.py
@@ -106,7 +106,7 @@ def load(
             if word == "motion":
                 num_frames = int(words[cnt + 2])
                 dt = float(words[cnt + 5])
-                motion.fps = round(1 / dt)
+                motion.set_fps(round(1 / dt))
                 cnt += 6
                 t = 0.0
                 range_num_dofs = range(motion.skel.num_dofs)

--- a/fairmotion/ops/motion.py
+++ b/fairmotion/ops/motion.py
@@ -184,7 +184,7 @@ def resample(motion, fps):
         t += dt
 
     motion.poses = poses_new
-    motion.fps = fps
+    motion.set_fps(fps)
     return motion
 
 

--- a/fairmotion/tasks/motion_graph/motion_graph.py
+++ b/fairmotion/tasks/motion_graph/motion_graph.py
@@ -156,7 +156,7 @@ class MotionGraph(object):
         self.motions = motions
         self.motion_files = motion_files
         self.skel = skel
-        self.fps = fps
+        self.set_fps(fps)
         self.base_length = base_length
         self.stride_length = stride_length
         self.blend_length = blend_length


### PR DESCRIPTION
Setting fps attribute directly, causes a mismatch in the value of fps_inv which is pre-computed at initialization for efficiency purposes.