### PR TITLE
Fixes to run and record motion graph

### DIFF
--- a/fairmotion/core/motion.py
+++ b/fairmotion/core/motion.py
@@ -162,7 +162,7 @@ class Skeleton(object):
     def num_end_effectors(self):
         self.end_effectors = []
         for j in self.joints:
-            if len(j.child_joint) == 0:
+            if len(j.child_joints) == 0:
                 self.end_effectors.append(j)
         return len(self.end_effectors)
 

--- a/fairmotion/tasks/motion_graph/motion_graph.py
+++ b/fairmotion/tasks/motion_graph/motion_graph.py
@@ -156,7 +156,7 @@ class MotionGraph(object):
         self.motions = motions
         self.motion_files = motion_files
         self.skel = skel
-        self.set_fps(fps)
+        self.fps = fps
         self.base_length = base_length
         self.stride_length = stride_length
         self.blend_length = blend_length
@@ -263,7 +263,7 @@ class MotionGraph(object):
             self.graph.edges[e]["num_visit"] = 0
 
     def create_motion_by_following(self, nodes):
-        motion = velocity.MotionWithVelocity(skel=self.skel)
+        motion = velocity.MotionWithVelocity(skel=self.skel, fps=self.fps)
         for i in range(len(nodes) - 1):
             n1 = nodes[i]
             n2 = nodes[i + 1]
@@ -369,7 +369,7 @@ class MotionGraph(object):
         length - length of the generated motion
         start_node - we can specify a start node if necessary
         """
-        motion = velocity.MotionWithVelocity(skel=self.skel)
+        motion = velocity.MotionWithVelocity(skel=self.skel, fps=self.fps)
         t_processed = 0.0
         nodes = list(self.graph.nodes)
         if start_node is None or start_node not in self.graph.nodes:
@@ -439,7 +439,7 @@ class MotionGraph(object):
         )
 
     def load_motion_at_idx(self, idx, file):
-        motion = velocity.MotionWithVelocity(skel=self.skel)
+        motion = velocity.MotionWithVelocity(skel=self.skel, fps=self.fps)
         motion = bvh.load(
             file=file,
             motion=motion,

--- a/fairmotion/viz/glut_viewer.py
+++ b/fairmotion/viz/glut_viewer.py
@@ -248,6 +248,10 @@ class Viewer:
         glutMainLoop()
 
     def save_screen(self, dir, name, format="png", render=False):
+        image = self.get_screen(render)
+        image.save(os.path.join(dir, "%s.%s" % (name, format)), format=format)
+
+    def get_screen(self, render=False):
         if render:
             self.draw_GL()
         x, y, width, height = glGetIntegerv(GL_VIEWPORT)
@@ -255,4 +259,4 @@ class Viewer:
         data = glReadPixels(x, y, width, height, GL_RGB, GL_UNSIGNED_BYTE)
         image = Image.frombytes("RGB", (width, height), data)
         image = image.transpose(Image.FLIP_TOP_BOTTOM)
-        image.save(os.path.join(dir, "%s.%s" % (name, format)), format=format)
+        return image


### PR DESCRIPTION
Initialize fps correctly to avoid using default 60fps
Keyboard callback to record and save gif when we press 'v'
Add thickness variable to control radius of cylindrical links