### PR TITLE
Fixes to motion prediction task

### DIFF
--- a/fairmotion/models/seq2seq.py
+++ b/fairmotion/models/seq2seq.py
@@ -39,7 +39,7 @@ class Seq2Seq(nn.Module):
         """
         hidden, cell, outputs = self.encoder(src)
         outputs = self.decoder(
-            tgt, hidden, cell, outputs, max_len, teacher_forcing_ratio,
+            tgt, hidden, cell, max_len, teacher_forcing_ratio,
         )
         return outputs
 

--- a/fairmotion/tasks/motion_prediction/preprocess.py
+++ b/fairmotion/tasks/motion_prediction/preprocess.py
@@ -110,7 +110,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--input-dir",
         required=True,
-        help="Location of the downloaded and unpacked zip file.",
+        help="Location of the downloaded and unpacked zip file. See "
+        "https://amass.is.tue.mpg.de/dataset for dataset",
     )
     parser.add_argument(
         "--output-dir", required=True, help="Where to store pickle files."
@@ -125,6 +126,7 @@ if __name__ == "__main__":
         type=str,
         help="Angle representation to convert data to",
         choices=["aa", "quat", "rotmat"],
+        default="aa",
     )
     parser.add_argument(
         "--src-len",


### PR DESCRIPTION
This PR addresses the issue in motion prediction training https://github.com/facebookresearch/fairmotion/issues/36. The changes included here are-
* Fix arguments to the LSTMDecoder forward method
* Add default rotation representation in preprocessing to avoid confusion
* Add pointer to dataset in CLI help