### PR TITLE
Remove first argument from add_one_frame called in amass_dip.load

### DIFF
--- a/fairmotion/data/amass_dip.py
+++ b/fairmotion/data/amass_dip.py
@@ -155,7 +155,7 @@ def load(
                             motion.skel.get_index_joint(joint_name)
                         ] = conversions.R2T(pose[major_joint_id])
                         major_joint_id += 1
-                motion.add_one_frame(pose_id * dt, pose_data)
+                motion.add_one_frame(pose_data)
 
     return motion
 


### PR DESCRIPTION
Seems like  #42 removed the first argument in `fairmotion/core/motion.add_one_frame`, which causes an error when I attempt to use the amass_dip data loader. The solution seems to be simply removing the first argument from the `add_one_frame` called in `fairmotion/data/amass_dip.py`  as well.