### PR TITLE
Small fix to demo

### DIFF
--- a/fairmotion/tasks/motion_graph/main.py
+++ b/fairmotion/tasks/motion_graph/main.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     # Construct Motion Graph
     mg = graph.MotionGraph(
         motions=motions_with_velocity,
-        motion_files=args.motion_files,
+        motion_files=motion_files,
         skel=skel,
         base_length=args.base_length,
         blend_length=args.blend_length,


### PR DESCRIPTION
bugfix: we were cleaning up the motion_files to make them canonical then not using it. Minor fix to use the cleaned filenames.

I found this when I was building my own motion graph for my baseline.