### PR TITLE
[clustering] Skip frames consistently while extracting manual features

### DIFF
--- a/fairmotion/tasks/clustering/features/manual.py
+++ b/fairmotion/tasks/clustering/features/manual.py
@@ -10,6 +10,7 @@ class ManualFeatures:
         self.joints = [joint.name for joint in motion.skel.joints]
         self.frame_time = 1 / motion.fps
         self.frame_num = 1
+        self.num_frames = motion.num_frames()
         self.offsets = [
             conversions.T2p(joint.xform_from_parent_joint)
             for joint in motion.skel.joints
@@ -36,7 +37,16 @@ class ManualFeatures:
         )
 
     def next_frame(self):
-        self.frame_num += 1
+        if self.frame_num + 1 > self.num_frames:
+            print("Reached end of motion!")
+        else:
+            self.frame_num += 1
+    
+    def skip_frames(self, num_frames):
+        if self.frame_num + num_frames > self.num_frames:
+            print("Reached end of motion!")
+        else:
+            self.frame_num += num_frames
 
     def transform_and_fetch_position(self, j):
         if j == "y_unit":

--- a/fairmotion/tasks/clustering/generate_features.py
+++ b/fairmotion/tasks/clustering/generate_features.py
@@ -24,7 +24,8 @@ thresholds = None
 def extract_manual_features(motion):
     features = []
     f = manual.ManualFeatures(motion, feat_utils.Skeleton.PFNN)
-    for _ in range(1, motion.num_frames(), 30):
+    frames_to_skip = 30
+    for _ in range(1, motion.num_frames(), frames_to_skip):
         pose_features = []
         pose_features.append(
             f.f_nmove("neck", "rhip", "lhip", "rwrist", 1.8 * f.hl)
@@ -115,7 +116,7 @@ def extract_manual_features(motion):
         )
         pose_features.append(f.f_fast("root", 2.3 * f.hl))
         features.append(pose_features)
-        f.next_frame()
+        f.skip_frames(frames_to_skip)
     return features
 
 


### PR DESCRIPTION
This change address the issue mentioned in https://github.com/facebookresearch/fairmotion/issues/50 