### PR TITLE
Changing bm_path to set to bm_fname in amass.py load_body_model() method

### DIFF
--- a/fairmotion/data/amass.py
+++ b/fairmotion/data/amass.py
@@ -125,7 +125,7 @@ def create_motion_from_amass_data(filename, bm, override_betas=None):
 def load_body_model(bm_path, num_betas=10, model_type="smplh"):
     comp_device = torch.device("cpu")
     bm = BodyModel(
-        bm_path=bm_path, 
+        bm_fname=bm_path, 
         num_betas=num_betas, 
         # model_type=model_type
     ).to(comp_device)

--- a/fairmotion/viz/body_visualizer.py
+++ b/fairmotion/viz/body_visualizer.py
@@ -68,7 +68,7 @@ def prepare_mesh_viewer(img_shape):
 def main(args):
     comp_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     bm = BodyModel(
-        model_type="smplh", bm_path=args.body_model_file, num_betas=10
+        model_type="smplh", bm_fname=args.body_model_file, num_betas=10
     ).to(comp_device)
     faces = c2c(bm.f)
 


### PR DESCRIPTION
Currently the instantiation of `class BodyModel` from the [human body prior repo](https://github.com/nghorbani/human_body_prior) is being passed the wrong argument.

This PR aims to change instances of:
```
bm = BodyModel(
        bm_path=bm_path, 
        num_betas=num_betas, 
        # model_type=model_type
    ).to(comp_device)
```

to

```
def load_body_model(bm_path, num_betas=10, model_type="smplh"):
    comp_device = torch.device("cpu")
    bm = BodyModel(
        bm_fname=bm_path,     # <--- line changed
        num_betas=num_betas, 
        # model_type=model_type
    ).to(comp_device)
    return bm
```
