### PR TITLE
Updated Transformer Model Attention Mask

### DIFF
--- a/fairmotion/models/transformer.py
+++ b/fairmotion/models/transformer.py
@@ -143,10 +143,14 @@ class TransformerModel(nn.Module):
         projected_src = self.encoder(src) * np.sqrt(self.ninp)
         pos_encoded_src = self.pos_encoder(projected_src)
         encoder_output = self.transformer_encoder(pos_encoded_src)
-        tgt_mask = self._generate_square_subsequent_mask(tgt.shape[0]).to(
-            device=tgt.device,
-        )
+
         if self.training:
+
+            # Create mask for training
+            tgt_mask = self._generate_square_subsequent_mask(tgt.shape[0]).to(
+                device=tgt.device,
+            )
+
             # Use last source pose as first input to decoder
             tgt = torch.cat((src[-1].unsqueeze(0), tgt[:-1]))
             pos_encoder_tgt = self.pos_encoder(


### PR DESCRIPTION
The baseline main attention mask did not match the size of the decoder input and would therefor result in a dimension mismatch when running self.transformer_decoder because the tgt when running in inference mode is only the last sequence in the source sequence (dimension in the sequence length is 1), which does not necessarily match the max_len dimension (24 for the baseline data).

This bug was determined by running preprocessed data from the DIP dataset for which the motion_prediction task was made compatible with: https://dip.is.tuebingen.mpg.de/download.php. Training over 10 epochs with a batchsize of 24 was used to qualify that the change worked using the CMU dataset (16430 training sequences, 670 validation sequences, and 805 test sequences). The results are shown in below
![loss](https://user-images.githubusercontent.com/68315344/142142592-ffd89c51-3673-48d2-b160-e1b90684fb76.png)
:

I'm currently using this repository for academic research, so any feedback on whether this is indeed the correct change (or advice on what the correct change should be would be greatly appreciated). Thank you