### PR TITLE
Conversion from R to R6D and vice versa

### DIFF
--- a/fairmotion/ops/conversions.py
+++ b/fairmotion/ops/conversions.py
@@ -181,6 +181,16 @@ def R2Q(R):
     )
 
 
+def R2R6D(R):
+    return R[..., 0:2]
+
+
+def R6D2R(R6D):
+    R3D = np.cross(R6D[..., 0], R6D[..., 1])
+    R = np.concatenate((R6D, np.expand_dims(R3D, axis=-1)), axis=-1)
+    return R
+
+
 def R2R(R):
     """
     This returns valid (corrected) rotation if input

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -49,6 +49,21 @@ class TestConversions(unittest.TestCase):
         for r, r_test in zip(R.flatten(), R_test.flatten()):
             self.assertAlmostEqual(r, r_test)
 
+    def test_R2R6D(self):
+        R = test_utils.get_random_R()
+        R6D = conversions.R2R6D(np.array([R]))
+
+        np.testing.assert_almost_equal(
+            conversions.R2R6D(np.array([R]))[0], conversions.R2R6D(R)
+        )
+        np.testing.assert_almost_equal(
+            conversions.R6D2R(np.array([R6D]))[0], conversions.R6D2R(R6D)
+        )
+
+        R_test = conversions.R6D2R(R6D[0])
+        for r, r_test in zip(R.flatten(), R_test.flatten()):
+            self.assertAlmostEqual(r, r_test)
+
     def test_Rp2T(self):
         T = test_utils.get_random_T()
         R, p = conversions.T2Rp(T)


### PR DESCRIPTION
R6 is the first 6 elements of the rotation matrix, making it less redundant for representation in neural networks.
Tested with `python tests/test_conversions.py`