### PR TITLE
Fix human_body_prior and body_visualizer dependencies

### DIFF
--- a/fairmotion/viz/smpl_body_visualizer.py
+++ b/fairmotion/viz/smpl_body_visualizer.py
@@ -27,9 +27,10 @@ import torch
 import tqdm
 import trimesh
 
+from body_visualizer.mesh import mesh_viewer
+from body_visualizer.tools.vis_tools import colors
 from human_body_prior.body_model.body_model import BodyModel
-from human_body_prior.mesh import MeshViewer
-from human_body_prior.tools.omni_tools import copy2cpu as c2c, colors
+from human_body_prior.tools.omni_tools import copy2cpu as c2c
 from fairmotion.data import bvh
 from fairmotion.ops import conversions, motion as motion_ops
 
@@ -48,7 +49,7 @@ def get_dfs_order(parents_np):
 
 
 def prepare_mesh_viewer(img_shape):
-    mv = MeshViewer(
+    mv = mesh_viewer.MeshViewer(
         width=img_shape[0], height=img_shape[1], use_offscreen=True
     )
     mv.scene = pyrender.Scene(
@@ -68,7 +69,7 @@ def prepare_mesh_viewer(img_shape):
 def main(args):
     comp_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     bm = BodyModel(
-        model_type="smplh", bm_fname=args.body_model_file, num_betas=10
+        bm_fname=args.body_model_file, num_betas=10
     ).to(comp_device)
     faces = c2c(bm.f)
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
     install_requires=[
         "black",
         "dataclasses",  # py3.6 backport required by human_body_prior
-        "human_body_prior",
         "matplotlib",
         "numpy",
         "pillow",
@@ -22,6 +21,8 @@ setup(
         "torch==1.6.0",
         "tqdm",
         "PyOpenGL==3.1.0",
+        "body_visualizer @ git+https://github.com/nghorbani/body_visualizer.git@be9cf756f8d1daed870d4c7ad1aa5cc3478a546c",
+        "human_body_prior @ git+https://github.com/nghorbani/human_body_prior.git@0278cb45180992e4d39ba1a11601f5ecc53ee148",
     ],
     packages=find_packages(exclude=["tests"]),
     classifiers=[


### PR DESCRIPTION
Several modules have been migrated away from `human_body_prior` project into a new `body_visualizer` repository. This broke `body_visualizer` visualization tool. This PR replaces PyPI dependency to the aforementioned GitHub projects and adds a direct link to specific commits of the repositories.

Verified that this set up works by generating a video with the command:
```
python fairmotion/viz/smpl_body_visualizer.py --input-file /Users/dgopinath/code/fairmotion_test/85_14_poses.bvh --body-model-file /Users/dgopinath/data/smplh/male/model.npz --video-output-file video.mp4
```