### PR TITLE
Fix ASF parsing

### DIFF
--- a/fairmotion/data/asfamc.py
+++ b/fairmotion/data/asfamc.py
@@ -213,7 +213,7 @@ def load(file, motion=None, scale=1.0, load_skel=True, load_motion=True):
                 joint.info["dof"] = 3
                 parent_joint = v.parent_joint
                 joint.xform_from_parent_joint = conversions.p2T(
-                    v.direction.squeeze() * v.length
+                    parent_joint.direction.squeeze() * parent_joint.length
                 )
             joints.append(joint)
             parent_joints.append(parent_joint)


### PR DESCRIPTION
When we loaded ASF/AMC and saved to BVH, the OFFSETs were off by one level in the hierarchy in the BVH file. This should fix it.

Before:
https://user-images.githubusercontent.com/1420491/175059967-d110d42d-515f-4469-a2da-8e1b2682b5fa.mov

After:
https://user-images.githubusercontent.com/1420491/175060003-c0d79d9d-5bf5-4238-a1b8-89053be85dea.mov
