### PR TITLE
Add license header

### DIFF
--- a/fairmotion/viz/pyrender_visualizer.py
+++ b/fairmotion/viz/pyrender_visualizer.py
@@ -1,3 +1,5 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+
 import os
 import sys
 


### PR DESCRIPTION
`fairmotion/viz/pyrender_visualizer.py` was missing license header leading to fb-internal alerts